### PR TITLE
Fix registering doctrine subscriber for kernel 6 with doctrine-bridge 7

### DIFF
--- a/src/Resources/config/services_subscriber_with_annotations.yml
+++ b/src/Resources/config/services_subscriber_with_annotations.yml
@@ -6,4 +6,8 @@ services:
         class: Ambta\DoctrineEncryptBundle\Subscribers\DoctrineEncryptSubscriber
         arguments: ["@ambta_doctrine_annotation_reader", "@ambta_doctrine_encrypt.encryptor"]
         tags:
-            -  { name: doctrine.event_subscriber }
+            - { name: 'doctrine.event_listener', event: 'postLoad' }
+            - { name: 'doctrine.event_listener', event: 'onFlush' }
+            - { name: 'doctrine.event_listener', event: 'preFlush' }
+            - { name: 'doctrine.event_listener', event: 'postFlush' }
+            - { name: 'doctrine.event_listener', event: 'onClear' }

--- a/src/Resources/config/services_subscriber_with_annotations_and_attributes.yml
+++ b/src/Resources/config/services_subscriber_with_annotations_and_attributes.yml
@@ -10,4 +10,8 @@ services:
         class: Ambta\DoctrineEncryptBundle\Subscribers\DoctrineEncryptSubscriber
         arguments: ["@ambta_doctrine_annotation_reader", "@ambta_doctrine_encrypt.encryptor"]
         tags:
-            -  { name: doctrine.event_subscriber }
+            - { name: 'doctrine.event_listener', event: 'postLoad' }
+            - { name: 'doctrine.event_listener', event: 'onFlush' }
+            - { name: 'doctrine.event_listener', event: 'preFlush' }
+            - { name: 'doctrine.event_listener', event: 'postFlush' }
+            - { name: 'doctrine.event_listener', event: 'onClear' }


### PR DESCRIPTION
Fixes #28 when using `symfony/doctrine-bridge` v7 with `symfony/http-kernel` v6.

The `doctrine.event_subscriber` is deprecated since symfony 6.3:

```
User Deprecated: Since symfony/doctrine-bridge 6.3: Using Doctrine subscribers as services is deprecated, declare listeners instead
```