### PR TITLE
Improve Entity Processing in postFlush Method by Skipping Uninitialized Proxy Objects

### DIFF
--- a/src/Subscribers/DoctrineEncryptSubscriber.php
+++ b/src/Subscribers/DoctrineEncryptSubscriber.php
@@ -197,6 +197,9 @@ class DoctrineEncryptSubscriber implements EventSubscriber
         $unitOfWork = $objectManager->getUnitOfWork();
         foreach ($unitOfWork->getIdentityMap() as $entityMap) {
             foreach ($entityMap as $entity) {
+                if (method_exists($entity, '__isInitialized') && !$entity->__isInitialized()) {
+                    continue;
+                }
                 $this->processFields($entity,$objectManager, false);
             }
         }


### PR DESCRIPTION
**Problem Statement:** In the current implementation of the `postFlush` method, the `$unitOfWork->getIdentityMap()` function returns all managed entities, including proxies and entities that are pending initialization. This leads to unnecessary processing of these entities, which impacts performance and introduces critical issues in productions.

**Impact:**

- **Performance Degradation**: Processing uninitialized proxy objects leads to unnecessary overhead.
- **Incorrect Behavior**: On the first flush, uninitialized proxy objects  trigger a SELECT, while on the second flush they save the entity because the fields are encrypted again. This wil also invoke other listeners which update the modified_by_user field.
- **Data Integrity Issues:** This cascading effect results in encrypting the entire entity multiple times, which is problematic, especially in a One-to-Many relation, causing significant inefficiencies in production.

**Proposed Solution:** To enhance performance and ensure only active (initialized) entities are processed, we propose modifying the postFlush method to check for and skip uninitialized proxy objects.

**Benefits of This Change:**

- **Performance Improvement:** By skipping uninitialized proxy objects, unnecessary processing is avoided.
- **Accuracy**: Ensures that only fully initialized and active entities are processed, reducing the likelihood of unexpected behavior.
- **Solve Critical Issues**: Prevents the unnecessary re-fetch and re-processing of entities, especially in One-to-Many relationships, thus maintaining data integrity and performance.

This approach still processes all fully initialized entities, including those not recently updated or inserted.

Im currently still testing the changes locally within my project. But this change looks promising.
