### PR TITLE
Fixed encryption on UPDATE operations in 5.4 branch

### DIFF
--- a/src/Subscribers/DoctrineEncryptSubscriber.php
+++ b/src/Subscribers/DoctrineEncryptSubscriber.php
@@ -175,8 +175,8 @@ class DoctrineEncryptSubscriber implements EventSubscriber
     {
         $objectManager = method_exists($onFlushEventArgs, 'getObjectManager') ? $onFlushEventArgs->getObjectManager() : $onFlushEventArgs->getEntityManager();
         $unitOfWork = $objectManager->getUnitOfWork();
-        foreach ([$unitOfWork->getScheduledEntityUpdates(), $unitOfWork->getScheduledEntityInsertions()] as $ScheduledEntities) {
-            foreach ($ScheduledEntities as $entity) {
+        foreach ([$unitOfWork->getScheduledEntityUpdates(), $unitOfWork->getScheduledEntityInsertions()] as $scheduledEntities) {
+            foreach ($scheduledEntities as $entity) {
                 $encryptCounterBefore = $this->encryptCounter;
                 $this->processFields($entity,$objectManager,true);
                 if ($this->encryptCounter > $encryptCounterBefore) {

--- a/src/Subscribers/DoctrineEncryptSubscriber.php
+++ b/src/Subscribers/DoctrineEncryptSubscriber.php
@@ -175,12 +175,14 @@ class DoctrineEncryptSubscriber implements EventSubscriber
     {
         $objectManager = method_exists($onFlushEventArgs, 'getObjectManager') ? $onFlushEventArgs->getObjectManager() : $onFlushEventArgs->getEntityManager();
         $unitOfWork = $objectManager->getUnitOfWork();
-        foreach ($unitOfWork->getScheduledEntityInsertions() as $entity) {
-            $encryptCounterBefore = $this->encryptCounter;
-            $this->processFields($entity,$objectManager,true);
-            if ($this->encryptCounter > $encryptCounterBefore) {
-                $classMetadata = $objectManager->getClassMetadata(get_class($entity));
-                $unitOfWork->recomputeSingleEntityChangeSet($classMetadata, $entity);
+        foreach ([$unitOfWork->getScheduledEntityUpdates(), $unitOfWork->getScheduledEntityInsertions()] as $ScheduledEntities) {
+            foreach ($ScheduledEntities as $entity) {
+                $encryptCounterBefore = $this->encryptCounter;
+                $this->processFields($entity,$objectManager,true);
+                if ($this->encryptCounter > $encryptCounterBefore) {
+                    $classMetadata = $objectManager->getClassMetadata(get_class($entity));
+                    $unitOfWork->recomputeSingleEntityChangeSet($classMetadata, $entity);
+                }
             }
         }
     }


### PR DESCRIPTION
Current 5.4.0 branch do not encrypt entities when doing UPDATE due to missed checks for `$unitOfWork->getScheduledEntityUpdates()` in `DoctrineEncryptSubscriber::onFlush`.

Fixed it by wrapping existing code in a loop.

Tested, works as intended.