### PR TITLE
Throw bundle-specific exceptions

### DIFF
--- a/TODO-6.0.md
+++ b/TODO-6.0.md
@@ -1,0 +1,3 @@
+# Things we need to do before we can release 6.0
+* [ ] Remove \Ambta\DoctrineEncryptBundle\DependencyInjection\DoctrineEncryptExtension::$wrapExceptions
+* [ ] Remove wrap_exceptions from configuration of the bundle

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,5 @@
+# Upgrading to 6.x
+## Breaking changes
+* Instead of exceptions directly from halite or defuse, you now get a `\DoctrineEncryptCommunity\DoctrineEncryptBundle\Exception\UnableToEncryptException` 
+  or a `\DoctrineEncryptCommunity\DoctrineEncryptBundle\Exception\UnableToDecryptException`, which both extend `\DoctrineEncryptCommunity\DoctrineEncryptBundle\Exception\DoctrineEncryptBundleException`.
+* Throw a `\DoctrineEncryptCommunity\DoctrineEncryptBundle\Exception\DoctrineEncryptBundleException` in case something goes wrong encrypting/decrypting 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -44,10 +44,13 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('%kernel.project_dir%')
                 ->end()
                 ->booleanNode('enable_secret_generation')
-                    ->defaultValue(true)
+                    ->defaultTrue()
                 ->end()
                 ->scalarNode('secret')
                     ->defaultValue(null)
+                ->end()
+                ->scalarNode('wrap_exceptions')
+                    ->defaultFalse()
                 ->end()
             ->end();
 

--- a/src/DependencyInjection/DoctrineEncryptExtension.php
+++ b/src/DependencyInjection/DoctrineEncryptExtension.php
@@ -19,6 +19,13 @@ use Symfony\Component\HttpKernel\Kernel;
  */
 class DoctrineEncryptExtension extends Extension
 {
+    /**
+     * Flag to test if we should wrap exceptions by our own exceptions.
+     *
+     * @internal
+     */
+    public static $wrapExceptions = false;
+
     public const SupportedEncryptorClasses = [
         'Defuse' => DefuseEncryptor::class,
         'Halite' => HaliteEncryptor::class,
@@ -79,6 +86,20 @@ class DoctrineEncryptExtension extends Extension
         // Symfony 7 (only attributes)
         } else {
             $loader->load('service_listeners_with_attributes.yml');
+        }
+
+        // Wrap exceptions
+        if ($config['wrap_exceptions']) {
+            self::$wrapExceptions = true;
+        } else {
+            trigger_deprecation(
+                'doctrineencryptbundle/doctrine-encrypt-bundle',
+                '5.4.2',
+                <<<'EOF'
+Starting from 6.0, all exceptions thrown by this library will be wrapped by \Ambta\DoctrineEncryptBundle\Exception\DoctrineEncryptBundleException or a child-class of it.
+You can start using these exceptions today by setting 'ambta_doctrine_encrypt.wrap_exceptions' to TRUE.
+EOF
+            );
         }
     }
 

--- a/src/Encryptors/DefuseEncryptor.php
+++ b/src/Encryptors/DefuseEncryptor.php
@@ -1,6 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ambta\DoctrineEncryptBundle\Encryptors;
+
+use Ambta\DoctrineEncryptBundle\DependencyInjection\DoctrineEncryptExtension;
+use Ambta\DoctrineEncryptBundle\Exception\UnableToDecryptException;
+use Ambta\DoctrineEncryptBundle\Exception\UnableToEncryptException;
 
 /**
  * Class for encrypting and decrypting with the defuse library.
@@ -20,13 +26,35 @@ class DefuseEncryptor implements EncryptorInterface
         $this->secret = $secret;
     }
 
+    /**
+     * @throws UnableToEncryptException
+     * @throws \Defuse\Crypto\Exception\CryptoException
+     */
     public function encrypt(string $data): string
     {
-        return \Defuse\Crypto\Crypto::encryptWithPassword($data, $this->secret);
+        try {
+            return \Defuse\Crypto\Crypto::encryptWithPassword($data, $this->secret);
+        } catch (\Throwable $e) {
+            if (DoctrineEncryptExtension::$wrapExceptions) {
+                throw new UnableToEncryptException($e->getMessage(), $e->getCode(), $e);
+            }
+            throw $e;
+        }
     }
 
+    /**
+     * @throws UnableToDecryptException
+     * @throws \Defuse\Crypto\Exception\CryptoException
+     */
     public function decrypt(string $data): string
     {
-        return \Defuse\Crypto\Crypto::decryptWithPassword($data, $this->secret);
+        try {
+            return \Defuse\Crypto\Crypto::decryptWithPassword($data, $this->secret);
+        } catch (\Throwable $e) {
+            if (DoctrineEncryptExtension::$wrapExceptions) {
+                throw new UnableToDecryptException($e->getMessage(), $e->getCode(), $e);
+            }
+            throw $e;
+        }
     }
 }

--- a/src/Encryptors/EncryptorInterface.php
+++ b/src/Encryptors/EncryptorInterface.php
@@ -2,6 +2,9 @@
 
 namespace Ambta\DoctrineEncryptBundle\Encryptors;
 
+use Ambta\DoctrineEncryptBundle\Exception\UnableToDecryptException;
+use Ambta\DoctrineEncryptBundle\Exception\UnableToEncryptException;
+
 /**
  * Encryptor interface for encryptors.
  *
@@ -13,6 +16,9 @@ interface EncryptorInterface
      * @param string $data Plain text to encrypt
      *
      * @return string Encrypted text
+     *
+     * @throws UnableToEncryptException
+     * @throws \Throwable
      */
     public function encrypt(string $data): string;
 
@@ -20,6 +26,9 @@ interface EncryptorInterface
      * @param string $data Encrypted text
      *
      * @return string Plain text
+     *
+     * @throws UnableToDecryptException
+     * @throws \Throwable
      */
     public function decrypt(string $data): string;
 }

--- a/src/Exception/DoctrineEncryptBundleException.php
+++ b/src/Exception/DoctrineEncryptBundleException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ambta\DoctrineEncryptBundle\Exception;
+
+class DoctrineEncryptBundleException extends \Exception
+{
+}

--- a/src/Exception/UnableToDecryptException.php
+++ b/src/Exception/UnableToDecryptException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ambta\DoctrineEncryptBundle\Exception;
+
+class UnableToDecryptException extends DoctrineEncryptBundleException
+{
+}

--- a/src/Exception/UnableToEncryptException.php
+++ b/src/Exception/UnableToEncryptException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ambta\DoctrineEncryptBundle\Exception;
+
+class UnableToEncryptException extends DoctrineEncryptBundleException
+{
+}

--- a/tests/Unit/DependencyInjection/DoctrineEncryptExtensionTest.php
+++ b/tests/Unit/DependencyInjection/DoctrineEncryptExtensionTest.php
@@ -8,12 +8,15 @@ use Ambta\DoctrineEncryptBundle\Encryptors\HaliteEncryptor;
 use ParagonIE\Halite\KeyFactory;
 use ParagonIE\HiddenString\HiddenString;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\ExpressionLanguage\Expression;
 
 class DoctrineEncryptExtensionTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @var DoctrineEncryptExtension
      */
@@ -198,6 +201,46 @@ class DoctrineEncryptExtensionTest extends TestCase
         }
         $this->assertIsString($actualSecret);
         $this->assertEquals($expectedSecret, $actualSecret);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testWrapExceptionsTriggersDeprecationWarningWhenNotDefiningTheOption(): void
+    {
+        $container = $this->createContainer();
+        $config    = [];
+
+        $this->expectDeprecation('Since doctrineencryptbundle/doctrine-encrypt-bundle 5.4.2: Starting from 6.0, all exceptions thrown by this library will be wrapped by \Ambta\DoctrineEncryptBundle\Exception\DoctrineEncryptBundleException or a child-class of it.
+You can start using these exceptions today by setting \'ambta_doctrine_encrypt.wrap_exceptions\' to TRUE.');
+        $this->extension->load([$config], $container);
+        $this->assertFalse(DoctrineEncryptExtension::$wrapExceptions);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testWrapExceptionsTriggersDeprecationWarningWhenDisabled(): void
+    {
+        $container = $this->createContainer();
+        $config    = ['wrap_exceptions' => false];
+
+        $this->expectDeprecation('Since doctrineencryptbundle/doctrine-encrypt-bundle 5.4.2: Starting from 6.0, all exceptions thrown by this library will be wrapped by \Ambta\DoctrineEncryptBundle\Exception\DoctrineEncryptBundleException or a child-class of it.
+You can start using these exceptions today by setting \'ambta_doctrine_encrypt.wrap_exceptions\' to TRUE.');
+        $this->extension->load([$config], $container);
+        $this->assertFalse(DoctrineEncryptExtension::$wrapExceptions);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testWrapExceptionsDoesNotTriggerDeprecationWarningWhenEnabled(): void
+    {
+        $container = $this->createContainer();
+        $config    = ['wrap_exceptions' => true];
+
+        $this->extension->load([$config], $container);
+        $this->assertTrue(DoctrineEncryptExtension::$wrapExceptions);
     }
 
     private function createContainer(): ContainerBuilder

--- a/tests/Unit/Encryptors/DefuseEncryptorTest.php
+++ b/tests/Unit/Encryptors/DefuseEncryptorTest.php
@@ -2,12 +2,26 @@
 
 namespace Ambta\DoctrineEncryptBundle\Tests\Unit\Encryptors;
 
+use Ambta\DoctrineEncryptBundle\DependencyInjection\DoctrineEncryptExtension;
 use Ambta\DoctrineEncryptBundle\Encryptors\DefuseEncryptor;
+use Ambta\DoctrineEncryptBundle\Exception\DoctrineEncryptBundleException;
 use PHPUnit\Framework\TestCase;
 
 class DefuseEncryptorTest extends TestCase
 {
     private const DATA = 'foobar';
+    /** @var bool */
+    private $originalWrapExceptions;
+
+    protected function setUp(): void
+    {
+        $this->originalWrapExceptions = DoctrineEncryptExtension::$wrapExceptions;
+    }
+
+    protected function tearDown(): void
+    {
+        DoctrineEncryptExtension::$wrapExceptions = $this->originalWrapExceptions;
+    }
 
     public function testEncrypt(): void
     {
@@ -22,5 +36,32 @@ class DefuseEncryptorTest extends TestCase
         $this->assertSame(self::DATA, $decrypted);
         $newkey = file_get_contents($keyfile);
         $this->assertSame($key, $newkey, 'The key must not be modified');
+    }
+
+    public function testEncryptorThrowsOwnExceptionWhenExceptionsAreNotWrapped(): void
+    {
+        DoctrineEncryptExtension::$wrapExceptions = false;
+
+        try {
+            (new DefuseEncryptor('not-a-valid-key'))->decrypt('foo');
+
+            $this->fail('The encryptor should have thrown an error');
+        } catch (\Throwable $e) {
+            $this->assertNotInstanceOf(\PHPUnit\Framework\Exception::class, $e);
+            $this->assertNotInstanceOf(DoctrineEncryptBundleException::class, $e);
+        }
+    }
+
+    public function testEncryptorThrowsBundleExceptionWhenExceptionsAreWrapped(): void
+    {
+        DoctrineEncryptExtension::$wrapExceptions = true;
+
+        try {
+            (new DefuseEncryptor('not-a-valid-key'))->decrypt('foo');
+
+            $this->fail('The encryptor should have thrown an error');
+        } catch (\Throwable $e) {
+            $this->assertInstanceOf(DoctrineEncryptBundleException::class, $e);
+        }
     }
 }

--- a/tests/Unit/Encryptors/HaliteEncryptorTest.php
+++ b/tests/Unit/Encryptors/HaliteEncryptorTest.php
@@ -2,12 +2,27 @@
 
 namespace Ambta\DoctrineEncryptBundle\Tests\Unit\Encryptors;
 
+use Ambta\DoctrineEncryptBundle\DependencyInjection\DoctrineEncryptExtension;
 use Ambta\DoctrineEncryptBundle\Encryptors\HaliteEncryptor;
+use Ambta\DoctrineEncryptBundle\Exception\DoctrineEncryptBundleException;
 use PHPUnit\Framework\TestCase;
 
 class HaliteEncryptorTest extends TestCase
 {
     private const DATA = 'foobar';
+
+    /** @var bool */
+    private $originalWrapExceptions;
+
+    protected function setUp(): void
+    {
+        $this->originalWrapExceptions = DoctrineEncryptExtension::$wrapExceptions;
+    }
+
+    protected function tearDown(): void
+    {
+        DoctrineEncryptExtension::$wrapExceptions = $this->originalWrapExceptions;
+    }
 
     public function testEncryptExtension(): void
     {
@@ -23,5 +38,32 @@ class HaliteEncryptorTest extends TestCase
         $decrypted = $halite->decrypt($encrypted);
 
         $this->assertSame(self::DATA, $decrypted);
+    }
+
+    public function testEncryptorThrowsOwnExceptionWhenExceptionsAreNotWrapped(): void
+    {
+        DoctrineEncryptExtension::$wrapExceptions = false;
+
+        try {
+            (new HaliteEncryptor('not-a-valid-key'))->encrypt('foo');
+
+            $this->fail('The encryptor should have thrown an error');
+        } catch (\Throwable $e) {
+            $this->assertNotInstanceOf(\PHPUnit\Framework\Exception::class, $e);
+            $this->assertNotInstanceOf(DoctrineEncryptBundleException::class, $e);
+        }
+    }
+
+    public function testEncryptorThrowsBundleExceptionWhenExceptionsAreWrapped(): void
+    {
+        DoctrineEncryptExtension::$wrapExceptions = true;
+
+        try {
+            (new HaliteEncryptor('not-a-valid-key'))->encrypt('foo');
+
+            $this->fail('The encryptor should have thrown an error');
+        } catch (\Throwable $e) {
+            $this->assertInstanceOf(DoctrineEncryptBundleException::class, $e);
+        }
     }
 }


### PR DESCRIPTION
I'd like to change the bundle so that we throw exceptions tied to this bundle, instead of specific ones from the underlying libraries.

To ease migration for users of this library, I made it optional in the current version of the library and left it disabled by default but plan to remove the optionality when we release 6.0.

I made the library throw a deprecation-warning if you are not using the new wrapped exceptions.

I have based this PR on #40 to avoid any changes from that PR to show up in here, but the changes should end up in branch 5.4 when #39 and #40 are merged in.