### PR TITLE
Update CI dependencies for GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   static-analysis:
     name: Static Analysis
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: "Checkout code"
@@ -22,7 +22,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "8.0"
+          php-version: "8.4"
 
       - name: "Validate composer.json"
         run: "composer validate --strict --no-check-lock"
@@ -50,14 +50,14 @@ jobs:
 
   tests:
     name: "Tests ${{ matrix.php-version }} ${{ matrix.dependency-versions }}"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: static-analysis
 
     strategy:
       fail-fast: false
       matrix:
         # normal, highest, non-dev installs
-        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         composer-options: ['--prefer-stable']
         dependency-versions: ['highest']
         include:
@@ -122,11 +122,11 @@ jobs:
           dependency-versions: "${{ matrix.dependency-versions }}"
           composer-options: "--prefer-dist --no-progress"
           working-directory: "demo/symfony6.x"
-        if: ${{ startsWith(matrix.php-version , '8.1') || startsWith(matrix.php-version , '8.2') || startsWith(matrix.php-version , '8.3') }}
+        if: ${{ startsWith(matrix.php-version , '8.1') || startsWith(matrix.php-version , '8.2') || startsWith(matrix.php-version , '8.3') || startsWith(matrix.php-version , '8.4') }}
 
       - name: Demo symfony6.x - Unit Tests
         run: demo/symfony6.x/vendor/bin/simple-phpunit -c demo/symfony6.x/phpunit.xml.dist
-        if: ${{ startsWith(matrix.php-version , '8.1') || startsWith(matrix.php-version , '8.2') || startsWith(matrix.php-version , '8.3') }}
+        if: ${{ startsWith(matrix.php-version , '8.1') || startsWith(matrix.php-version , '8.2') || startsWith(matrix.php-version , '8.3') || startsWith(matrix.php-version , '8.4') }}
 
       - name: Demo symfony6.x-orm3 - Install  dependencies
         uses: "ramsey/composer-install@v3"
@@ -134,11 +134,11 @@ jobs:
           dependency-versions: "${{ matrix.dependency-versions }}"
           composer-options:    "--prefer-dist --no-progress"
           working-directory:   "demo/symfony6.x-orm3"
-        if:   ${{ startsWith(matrix.php-version , '8.1') || startsWith(matrix.php-version , '8.2') || startsWith(matrix.php-version , '8.3') }}
+        if:   ${{ startsWith(matrix.php-version , '8.1') || startsWith(matrix.php-version , '8.2') || startsWith(matrix.php-version , '8.3') || startsWith(matrix.php-version , '8.4') }}
 
       - name: Demo symfony6.x-orm3 - Unit Tests
         run:  demo/symfony6.x/vendor/bin/simple-phpunit -c demo/symfony6.x-orm3/phpunit.xml.dist
-        if:   ${{ startsWith(matrix.php-version , '8.1') || startsWith(matrix.php-version , '8.2') || startsWith(matrix.php-version , '8.3') }}
+        if:   ${{ startsWith(matrix.php-version , '8.1') || startsWith(matrix.php-version , '8.2') || startsWith(matrix.php-version , '8.3') || startsWith(matrix.php-version , '8.4') }}
 
       - name: Demo symfony7.x - Install  dependencies
         uses: "ramsey/composer-install@v3"
@@ -146,8 +146,8 @@ jobs:
           dependency-versions: "${{ matrix.dependency-versions }}"
           composer-options: "--prefer-dist --no-progress"
           working-directory: "demo/symfony7.x"
-        if: ${{ startsWith(matrix.php-version , '8.2') || startsWith(matrix.php-version , '8.3') }}
+        if: ${{ startsWith(matrix.php-version , '8.2') || startsWith(matrix.php-version , '8.3') || startsWith(matrix.php-version , '8.4') }}
 
       - name: Demo symfony7.x - Unit Tests
         run: demo/symfony7.x/vendor/bin/simple-phpunit -c demo/symfony7.x/phpunit.xml.dist
-        if: ${{ startsWith(matrix.php-version , '8.2') || startsWith(matrix.php-version , '8.3') }}
+        if: ${{ startsWith(matrix.php-version , '8.2') || startsWith(matrix.php-version , '8.3') || startsWith(matrix.php-version , '8.4') }}

--- a/demo/symfony5.4/src/Repository/Attribute/SecretRepository.php
+++ b/demo/symfony5.4/src/Repository/Attribute/SecretRepository.php
@@ -16,8 +16,8 @@ if (!interface_exists('\Doctrine\Common\Persistence\ManagerRegistry')) {
 if (PHP_VERSION_ID >= 80000) {
     /**
      * @method Secret|null find($id, $lockMode = null, $lockVersion = null)
-     * @method Secret|null findOneBy(array $criteria, array $orderBy = null)
-     * @method Secret[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+     * @method Secret|null findOneBy(array $criteria, ?array $orderBy = null)
+     * @method Secret[]    findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null)
      */
     class SecretRepository extends AbstractSecretRepository
     {

--- a/demo/symfony6.x/config/packages/doctrine.yaml
+++ b/demo/symfony6.x/config/packages/doctrine.yaml
@@ -9,6 +9,7 @@ doctrine:
         auto_generate_proxy_classes: true
         naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
         auto_mapping: true
+        report_fields_where_declared: true
         mappings:
             Annotation:
                 type: 'annotation'

--- a/demo/symfony6.x/phpunit.xml.dist
+++ b/demo/symfony6.x/phpunit.xml.dist
@@ -15,6 +15,7 @@
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
         <server name="SYMFONY_PHPUNIT_VERSION" value="9.5" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled" />
     </php>
 
     <testsuites>

--- a/demo/symfony6.x/src/Repository/Attribute/SecretRepository.php
+++ b/demo/symfony6.x/src/Repository/Attribute/SecretRepository.php
@@ -16,8 +16,8 @@ if (!interface_exists('\Doctrine\Common\Persistence\ManagerRegistry')) {
 if (PHP_VERSION_ID >= 80000) {
     /**
      * @method Secret|null find($id, $lockMode = null, $lockVersion = null)
-     * @method Secret|null findOneBy(array $criteria, array $orderBy = null)
-     * @method Secret[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+     * @method Secret|null findOneBy(array $criteria, ?array $orderBy = null)
+     * @method Secret[]    findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null)
      */
     class SecretRepository extends AbstractSecretRepository
     {

--- a/demo/symfony7.x/phpunit.xml.dist
+++ b/demo/symfony7.x/phpunit.xml.dist
@@ -14,6 +14,7 @@
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
         <server name="SYMFONY_PHPUNIT_VERSION" value="9.5" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled" />
     </php>
 
     <testsuites>

--- a/demo/symfony7.x/src/Repository/Attribute/SecretRepository.php
+++ b/demo/symfony7.x/src/Repository/Attribute/SecretRepository.php
@@ -16,8 +16,8 @@ if (!interface_exists('\Doctrine\Common\Persistence\ManagerRegistry')) {
 if (PHP_VERSION_ID >= 80000) {
     /**
      * @method Secret|null find($id, $lockMode = null, $lockVersion = null)
-     * @method Secret|null findOneBy(array $criteria, array $orderBy = null)
-     * @method Secret[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+     * @method Secret|null findOneBy(array $criteria, ?array $orderBy = null)
+     * @method Secret[]    findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null)
      */
     class SecretRepository extends AbstractSecretRepository
     {


### PR DESCRIPTION
* Added PHP 8.4 to the CI matrix;
* Bumped versions for reusable actions;
* Fixed some deprecations found with PHP 8.4.

I had to use `SYMFONY_DEPRECATIONS_HELPER=disabled` in the demo for Symfony 6 and 7 because the tests were failing because the existing deprecations. I tried to fix this issue with [more sensible values](https://symfony.com/doc/current/components/phpunit_bridge.html#internal-deprecations), but it was not working.

