### PR TITLE
Fix compatibility with "doctrine/orm" 3.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "8.0"
+          php-version: "8.4"
           extensions: pdo, pdo_sqlite
 
       - name: "Validate composer.json"
@@ -36,6 +36,9 @@ jobs:
         with:
             composer-options: "--prefer-stable"
             dependency-versions: 'highest'
+
+      - name: "Trigger install for PHPUnit dependencies"
+        run:  "vendor/bin/simple-phpunit --version"
 
       - name: "PHPStan"
         run:  "vendor/bin/phpstan analyze"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,31 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Class Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataInfo not found\\.$#"
+			count: 1
+			path: src/Command/AbstractCommand.php
+
+		-
+			message: "#^Class Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataInfo not found\\.$#"
+			count: 1
+			path: src/Command/DoctrineDecryptDatabaseCommand.php
+
+		-
+			message: "#^Class Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataInfo not found\\.$#"
+			count: 1
+			path: src/Command/DoctrineEncryptStatusCommand.php
+
+		-
+			message: "#^Call to an undefined static method Doctrine\\\\ORM\\\\EntityManager\\:\\:create\\(\\)\\.$#"
+			count: 1
+			path: tests/Functional/AbstractFunctionalTestCase.php
+
+		-
+			message: "#^Call to static method createAnnotationMetadataConfiguration\\(\\) on an unknown class Doctrine\\\\ORM\\\\Tools\\\\Setup\\.$#"
+			count: 1
+			path: tests/Functional/AbstractFunctionalTestCase.php
+
+		-
+			message: "#^Instantiated class Doctrine\\\\DBAL\\\\Logging\\\\DebugStack not found\\.$#"
+			count: 1
+			path: tests/Functional/AbstractFunctionalTestCase.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,9 @@
+includes:
+    - phpstan-baseline.neon
+
 parameters:
 	level: 0
 	paths:
 		- src
-		#- tests
+		- tests
 	tmpDir: .phpstan-cache

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -7,6 +7,7 @@ use Ambta\DoctrineEncryptBundle\Subscribers\DoctrineEncryptSubscriber;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Symfony\Component\Console\Command\Command;
 
@@ -81,7 +82,7 @@ abstract class AbstractCommand extends Command
         $metaDataArray = $this->entityManager->getMetadataFactory()->getAllMetadata();
 
         foreach ($metaDataArray as $entityMetaData) {
-            if ($entityMetaData instanceof ClassMetadataInfo and $entityMetaData->isMappedSuperclass) {
+            if (($entityMetaData instanceof ClassMetadataInfo || $entityMetaData instanceof ClassMetadata) && $entityMetaData->isMappedSuperclass) {
                 continue;
             }
 

--- a/src/Command/DoctrineDecryptDatabaseCommand.php
+++ b/src/Command/DoctrineDecryptDatabaseCommand.php
@@ -3,6 +3,7 @@
 namespace Ambta\DoctrineEncryptBundle\Command;
 
 use Ambta\DoctrineEncryptBundle\DependencyInjection\DoctrineEncryptExtension;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
@@ -63,7 +64,7 @@ class DoctrineDecryptDatabaseCommand extends AbstractCommand
         // Set counter and loop through entity manager meta data
         $propertyCount = 0;
         foreach ($metaDataArray as $metaData) {
-            if ($metaData instanceof ClassMetadataInfo and $metaData->isMappedSuperclass) {
+            if (($metaData instanceof ClassMetadataInfo || $metaData instanceof ClassMetadata) && $metaData->isMappedSuperclass) {
                 continue;
             }
 

--- a/src/Command/DoctrineEncryptStatusCommand.php
+++ b/src/Command/DoctrineEncryptStatusCommand.php
@@ -2,6 +2,7 @@
 
 namespace Ambta\DoctrineEncryptBundle\Command;
 
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -27,7 +28,7 @@ class DoctrineEncryptStatusCommand extends AbstractCommand
 
         $totalCount = 0;
         foreach ($metaDataArray as $metaData) {
-            if ($metaData instanceof ClassMetadataInfo && $metaData->isMappedSuperclass) {
+            if (($metaData instanceof ClassMetadataInfo || $metaData instanceof ClassMetadata) && $metaData->isMappedSuperclass) {
                 continue;
             }
 

--- a/tests/Functional/AbstractFunctionalTestCase.php
+++ b/tests/Functional/AbstractFunctionalTestCase.php
@@ -237,9 +237,9 @@ abstract class AbstractFunctionalTestCase extends TestCase
      */
     public function assertStringDoesNotContain($needle, $string, $ignoreCase = false, $message = ''): void
     {
-        $this->assertIsString($needle, $message);
-        $this->assertIsString($string, $message);
-        $this->assertIsBool($ignoreCase, $message);
+        static::assertIsString($needle, $message);
+        static::assertIsString($string, $message);
+        static::assertIsBool($ignoreCase, $message);
 
         $constraint = new LogicalNot(new StringContains(
             $needle,

--- a/tests/Functional/BasicQueryTest/AbstractBasicQueryTestCase.php
+++ b/tests/Functional/BasicQueryTest/AbstractBasicQueryTestCase.php
@@ -18,44 +18,44 @@ abstract class AbstractBasicQueryTestCase extends AbstractFunctionalTestCase
         $this->entityManager->flush();
 
         // Start transaction; insert; commit
-        $this->assertEquals('top secret information', $user->getSecret());
-        $this->assertEquals(3, $this->getCurrentQueryCount());
+        static::assertEquals('top secret information', $user->getSecret());
+        static::assertEquals(3, $this->getCurrentQueryCount());
     }
 
     public function testNoUpdateOnReadEncrypted(): void
     {
         $this->entityManager->beginTransaction();
-        $this->assertEquals(1, $this->getCurrentQueryCount());
+        static::assertEquals(1, $this->getCurrentQueryCount());
 
         $user = new CascadeTarget();
         $user->setNotSecret('My public information');
         $user->setSecret('top secret information');
         $this->entityManager->persist($user);
         $this->entityManager->flush();
-        $this->assertEquals(2, $this->getCurrentQueryCount());
+        static::assertEquals(2, $this->getCurrentQueryCount());
 
         // Test if no query is executed when doing nothing
         $this->entityManager->flush();
-        $this->assertEquals(2, $this->getCurrentQueryCount());
+        static::assertEquals(2, $this->getCurrentQueryCount());
 
         // Test if no query is executed when reading unrelated field
         $user->getNotSecret();
         $this->entityManager->flush();
-        $this->assertEquals(2, $this->getCurrentQueryCount());
+        static::assertEquals(2, $this->getCurrentQueryCount());
 
         // Test if no query is executed when reading related field and if field is valid
-        $this->assertEquals('top secret information', $user->getSecret());
+        static::assertEquals('top secret information', $user->getSecret());
         $this->entityManager->flush();
-        $this->assertEquals(2, $this->getCurrentQueryCount());
+        static::assertEquals(2, $this->getCurrentQueryCount());
 
         // Test if 1 query is executed when updating entity
         $user->setSecret('top secret information change');
         $this->entityManager->flush();
-        $this->assertEquals(3, $this->getCurrentQueryCount());
-        $this->assertEquals('top secret information change', $user->getSecret());
+        static::assertEquals(3, $this->getCurrentQueryCount());
+        static::assertEquals('top secret information change', $user->getSecret());
 
         $this->entityManager->rollback();
-        $this->assertEquals(4, $this->getCurrentQueryCount());
+        static::assertEquals(4, $this->getCurrentQueryCount());
     }
 
     public function testStoredDataIsEncrypted(): void
@@ -92,7 +92,7 @@ abstract class AbstractBasicQueryTestCase extends AbstractFunctionalTestCase
         $this->entityManager->flush();
 
         // start transaction, insert, commit
-        $this->assertEquals(3, $this->getCurrentQueryCount());
+        static::assertEquals(3, $this->getCurrentQueryCount());
 
         // Remove all logged queries
         $this->resetQueryStack();
@@ -103,6 +103,6 @@ abstract class AbstractBasicQueryTestCase extends AbstractFunctionalTestCase
 
         // Verify there are no queries executed
         $this->assertNull($this->getLatestUpdateQuery());
-        $this->assertEquals(0, $this->getCurrentQueryCount());
+        static::assertEquals(0, $this->getCurrentQueryCount());
     }
 }

--- a/tests/Functional/BasicQueryTest/BasicQueryHaliteTest.php
+++ b/tests/Functional/BasicQueryTest/BasicQueryHaliteTest.php
@@ -15,7 +15,7 @@ class BasicQueryHaliteTest extends AbstractBasicQueryTestCase
     public function setUp(): void
     {
         if (!extension_loaded('sodium') && !class_exists('ParagonIE_Sodium_Compat')) {
-            $this->markTestSkipped('This test only runs when the sodium extension is enabled.');
+            static::markTestSkipped('This test only runs when the sodium extension is enabled.');
 
             return;
         }

--- a/tests/Functional/DoctrineEncryptSubscriber/AbstractDoctrineEncryptSubscriberTestCase.php
+++ b/tests/Functional/DoctrineEncryptSubscriber/AbstractDoctrineEncryptSubscriberTestCase.php
@@ -33,20 +33,20 @@ abstract class AbstractDoctrineEncryptSubscriberTestCase extends AbstractFunctio
         $connection = $em->getConnection();
         $stmt       = $connection->prepare('SELECT * from owner WHERE id = ?');
         $owners     = $em->getRepository(Owner::class)->findAll();
-        $this->assertCount(1, $owners);
+        static::assertCount(1, $owners);
         /** @var Owner $owner */
         $owner = $owners[0];
-        $this->assertEquals($secret, $owner->getSecret());
-        $this->assertEquals($notSecret, $owner->getNotSecret());
+        static::assertEquals($secret, $owner->getSecret());
+        static::assertEquals($notSecret, $owner->getNotSecret());
         $stmt->bindValue(1, $owner->getId());
         $results = $this->executeStatementFetchAll($stmt);
         $this->assertCount(1, $results);
         $result = $results[0];
-        $this->assertEquals($notSecret, $result['notSecret']);
+        static::assertEquals($notSecret, $result['notSecret']);
         $this->assertNotEquals($secret, $result['secret']);
         $this->assertStringEndsWith('<ENC>', $result['secret']);
         $decrypted = $this->encryptor->decrypt(str_replace('<ENC>', '', $result['secret']));
-        $this->assertEquals($secret, $decrypted);
+        static::assertEquals($secret, $decrypted);
     }
 
     public function testEncryptionCascades(): void
@@ -73,17 +73,17 @@ abstract class AbstractDoctrineEncryptSubscriberTestCase extends AbstractFunctio
         $this->assertCount(1, $cascadeTargets);
         /** @var CascadeTarget $cascadeTarget */
         $cascadeTarget = $cascadeTargets[0];
-        $this->assertEquals($secret, $cascadeTarget->getSecret());
-        $this->assertEquals($notSecret, $cascadeTarget->getNotSecret());
+        static::assertEquals($secret, $cascadeTarget->getSecret());
+        static::assertEquals($notSecret, $cascadeTarget->getNotSecret());
         $stmt->bindValue(1, $cascadeTarget->getId());
         $results = $this->executeStatementFetchAll($stmt);
         $this->assertCount(1, $results);
         $result = $results[0];
-        $this->assertEquals($notSecret, $result['notSecret']);
+        static::assertEquals($notSecret, $result['notSecret']);
         $this->assertNotEquals($secret, $result['secret']);
         $this->assertStringEndsWith('<ENC>', $result['secret']);
         $decrypted = $this->encryptor->decrypt(str_replace('<ENC>', '', $result['secret']));
-        $this->assertEquals($secret, $decrypted);
+        static::assertEquals($secret, $decrypted);
     }
 
     public function testEncryptionClassTableInheritance(): void
@@ -171,8 +171,8 @@ abstract class AbstractDoctrineEncryptSubscriberTestCase extends AbstractFunctio
         $owners = $em->getRepository(Owner::class)->findAll();
         /** @var Owner $owner */
         foreach ($owners as $owner) {
-            $this->assertEquals($secret, $owner->getSecret());
-            $this->assertEquals($notSecret, $owner->getNotSecret());
+            static::assertEquals($secret, $owner->getSecret());
+            static::assertEquals($notSecret, $owner->getNotSecret());
         }
         $this->resetQueryStack();
         $this->assertCount(0, $this->getDebugQueries());
@@ -180,7 +180,7 @@ abstract class AbstractDoctrineEncryptSubscriberTestCase extends AbstractFunctio
         $em->flush();
         $afterFlush = $this->subscriber->encryptCounter;
         // No encryption should have happened because we didn't change anything.
-        $this->assertEquals($beforeFlush, $afterFlush);
+        static::assertEquals($beforeFlush, $afterFlush);
         // No queries happened because we didn't change anything.
         $this->assertCount(0, $this->getDebugQueries(), "Unexpected queries:\n".var_export($this->getDebugQueries(), true));
 
@@ -189,7 +189,7 @@ abstract class AbstractDoctrineEncryptSubscriberTestCase extends AbstractFunctio
         $em->flush();
         $afterFlush = $this->subscriber->encryptCounter;
         // No encryption should have happened because we didn't change anything.
-        $this->assertEquals($beforeFlush, $afterFlush);
+        static::assertEquals($beforeFlush, $afterFlush);
         // No queries happened because we didn't change anything.
         $this->assertCount(0, $this->getDebugQueries(), "Unexpected queries:\n".var_export($this->getDebugQueries(), true));
 
@@ -199,7 +199,7 @@ abstract class AbstractDoctrineEncryptSubscriberTestCase extends AbstractFunctio
         $result                  = $results[0];
         $shouldBeTheSameAsBefore = $result['secret'];
         $this->assertStringEndsWith('<ENC>', $shouldBeTheSameAsBefore); // is encrypted
-        $this->assertEquals($originalEncryption, $shouldBeTheSameAsBefore);
+        static::assertEquals($originalEncryption, $shouldBeTheSameAsBefore);
     }
 
     public function testEncryptionDoesNotHappenWhenThereIsNoChangeClassInheritance(): void
@@ -332,7 +332,7 @@ abstract class AbstractDoctrineEncryptSubscriberTestCase extends AbstractFunctio
 
         $this->assertStringEndsWith(DoctrineEncryptSubscriber::ENCRYPTION_MARKER, $passwordData);
         $this->assertStringDoesNotContain('my secret', $passwordData);
-        $this->assertEquals('MY SECRET', $secret);
+        static::assertEquals('MY SECRET', $secret);
     }
 
     public function testEntityWithDateTimeJsonAndArrayProperties()
@@ -361,7 +361,7 @@ abstract class AbstractDoctrineEncryptSubscriberTestCase extends AbstractFunctio
         // Doctrine datetime type is only for date and time. milliseconds and timezone is not stored.
         // We only test the date and time accordingly
         // https://www.doctrine-project.org/projects/doctrine-dbal/en/3.7/reference/types.html#datetime
-        $this->assertEquals($datetime->format('Y-m-d\\TH:i:s'), $entityDate->format('Y-m-d\\TH:i:s'));
-        $this->assertEquals($jsonArray, $entityJson);
+        static::assertEquals($datetime->format('Y-m-d\\TH:i:s'), $entityDate->format('Y-m-d\\TH:i:s'));
+        static::assertEquals($jsonArray, $entityJson);
     }
 }

--- a/tests/Functional/DoctrineEncryptSubscriber/DoctrineEncryptSubscriberHaliteTest.php
+++ b/tests/Functional/DoctrineEncryptSubscriber/DoctrineEncryptSubscriberHaliteTest.php
@@ -15,7 +15,7 @@ class DoctrineEncryptSubscriberHaliteTest extends AbstractDoctrineEncryptSubscri
     public function setUp(): void
     {
         if (!extension_loaded('sodium') && !class_exists('ParagonIE_Sodium_Compat')) {
-            $this->markTestSkipped('This test only runs when the sodium extension is enabled.');
+            static::markTestSkipped('This test only runs when the sodium extension is enabled.');
 
             return;
         }

--- a/tests/Unit/DependencyInjection/DoctrineEncryptExtensionTest.php
+++ b/tests/Unit/DependencyInjection/DoctrineEncryptExtensionTest.php
@@ -41,7 +41,7 @@ class DoctrineEncryptExtensionTest extends TestCase
         $container = $this->createContainer();
         $this->extension->load([[]], $container);
 
-        $this->assertSame(HaliteEncryptor::class, $container->getParameter('ambta_doctrine_encrypt.encryptor_class_name'));
+        static::assertSame(HaliteEncryptor::class, $container->getParameter('ambta_doctrine_encrypt.encryptor_class_name'));
     }
 
     public function testConfigLoadHalite(): void
@@ -52,7 +52,7 @@ class DoctrineEncryptExtensionTest extends TestCase
         ];
         $this->extension->load([$config], $container);
 
-        $this->assertSame(HaliteEncryptor::class, $container->getParameter('ambta_doctrine_encrypt.encryptor_class_name'));
+        static::assertSame(HaliteEncryptor::class, $container->getParameter('ambta_doctrine_encrypt.encryptor_class_name'));
     }
 
     public function testConfigLoadDefuse(): void
@@ -64,7 +64,7 @@ class DoctrineEncryptExtensionTest extends TestCase
         ];
         $this->extension->load([$config], $container);
 
-        $this->assertSame(DefuseEncryptor::class, $container->getParameter('ambta_doctrine_encrypt.encryptor_class_name'));
+        static::assertSame(DefuseEncryptor::class, $container->getParameter('ambta_doctrine_encrypt.encryptor_class_name'));
     }
 
     public function testConfigLoadCustomEncryptor(): void
@@ -75,7 +75,7 @@ class DoctrineEncryptExtensionTest extends TestCase
         ];
         $this->extension->load([$config], $container);
 
-        $this->assertSame(self::class, $container->getParameter('ambta_doctrine_encrypt.encryptor_class_name'));
+        static::assertSame(self::class, $container->getParameter('ambta_doctrine_encrypt.encryptor_class_name'));
     }
 
     public function testConfigImpossibleToUseSecretAndSecretDirectoryPath(): void
@@ -99,10 +99,10 @@ class DoctrineEncryptExtensionTest extends TestCase
         ];
         $this->extension->load([$config], $container);
 
-        $this->assertIsString($container->getParameter('ambta_doctrine_encrypt.secret'));
+        static::assertIsString($container->getParameter('ambta_doctrine_encrypt.secret'));
         $this->assertStringNotContainsString('Halite', $container->getParameter('ambta_doctrine_encrypt.secret'));
         $this->assertStringNotContainsString('.key', $container->getParameter('ambta_doctrine_encrypt.secret'));
-        $this->assertEquals('my-secret', $container->getParameter('ambta_doctrine_encrypt.secret'));
+        static::assertEquals('my-secret', $container->getParameter('ambta_doctrine_encrypt.secret'));
     }
 
     public function testHaliteSecretIsCreatedWhenSecretFileDoesNotExistAndSecretCreationIsEnabled(): void
@@ -120,9 +120,9 @@ class DoctrineEncryptExtensionTest extends TestCase
         } else {
             $actualSecret = $secretArgument;
         }
-        $this->assertIsString($actualSecret);
+        static::assertIsString($actualSecret);
         $actualSecretOnDisk = file_get_contents($this->temporaryDirectory.DIRECTORY_SEPARATOR.'.Halite.key');
-        $this->assertEquals($actualSecret, $actualSecretOnDisk);
+        static::assertEquals($actualSecret, $actualSecretOnDisk);
 
         try {
             KeyFactory::importEncryptionKey(new HiddenString($actualSecret));
@@ -147,9 +147,9 @@ class DoctrineEncryptExtensionTest extends TestCase
         } else {
             $actualSecret = $secretArgument;
         }
-        $this->assertIsString($actualSecret);
+        static::assertIsString($actualSecret);
         $actualSecretOnDisk = file_get_contents($this->temporaryDirectory.DIRECTORY_SEPARATOR.'.Defuse.key');
-        $this->assertEquals($actualSecret, $actualSecretOnDisk);
+        static::assertEquals($actualSecret, $actualSecretOnDisk);
 
         if (strlen(hex2bin($actualSecret)) !== 255) {
             $this->fail('Generated key is not valid');
@@ -199,8 +199,8 @@ class DoctrineEncryptExtensionTest extends TestCase
         } else {
             $actualSecret = $secretArgument;
         }
-        $this->assertIsString($actualSecret);
-        $this->assertEquals($expectedSecret, $actualSecret);
+        static::assertIsString($actualSecret);
+        static::assertEquals($expectedSecret, $actualSecret);
     }
 
     /**

--- a/tests/Unit/Encryptors/DefuseEncryptorTest.php
+++ b/tests/Unit/Encryptors/DefuseEncryptorTest.php
@@ -33,9 +33,9 @@ class DefuseEncryptorTest extends TestCase
         $this->assertNotSame(self::DATA, $encrypted);
         $decrypted = $defuse->decrypt($encrypted);
 
-        $this->assertSame(self::DATA, $decrypted);
+        static::assertSame(self::DATA, $decrypted);
         $newkey = file_get_contents($keyfile);
-        $this->assertSame($key, $newkey, 'The key must not be modified');
+        static::assertSame($key, $newkey, 'The key must not be modified');
     }
 
     public function testEncryptorThrowsOwnExceptionWhenExceptionsAreNotWrapped(): void

--- a/tests/Unit/Encryptors/HaliteEncryptorTest.php
+++ b/tests/Unit/Encryptors/HaliteEncryptorTest.php
@@ -27,7 +27,7 @@ class HaliteEncryptorTest extends TestCase
     public function testEncryptExtension(): void
     {
         if (!extension_loaded('sodium') && !class_exists('ParagonIE_Sodium_Compat')) {
-            $this->markTestSkipped('This test only runs when the sodium extension is enabled.');
+            static::markTestSkipped('This test only runs when the sodium extension is enabled.');
         }
         $keyfile = __DIR__.'/fixtures/halite.key';
         $key     = file_get_contents($keyfile);
@@ -37,7 +37,7 @@ class HaliteEncryptorTest extends TestCase
         $this->assertNotSame(self::DATA, $encrypted);
         $decrypted = $halite->decrypt($encrypted);
 
-        $this->assertSame(self::DATA, $decrypted);
+        static::assertSame(self::DATA, $decrypted);
     }
 
     public function testEncryptorThrowsOwnExceptionWhenExceptionsAreNotWrapped(): void

--- a/tests/Unit/Subscribers/DoctrineEncryptSubscriberTest.php
+++ b/tests/Unit/Subscribers/DoctrineEncryptSubscriberTest.php
@@ -116,11 +116,11 @@ class DoctrineEncryptSubscriberTest extends TestCase
     {
         $replaceEncryptor = $this->createMock(EncryptorInterface::class);
 
-        $this->assertSame($this->encryptor, $this->subscriber->getEncryptor());
+        static::assertSame($this->encryptor, $this->subscriber->getEncryptor());
         $this->subscriber->setEncryptor($replaceEncryptor);
-        $this->assertSame($replaceEncryptor, $this->subscriber->getEncryptor());
+        static::assertSame($replaceEncryptor, $this->subscriber->getEncryptor());
         $this->subscriber->restoreEncryptor();
-        $this->assertSame($this->encryptor, $this->subscriber->getEncryptor());
+        static::assertSame($this->encryptor, $this->subscriber->getEncryptor());
     }
 
     private function triggerProcessFields(object $entity, bool $encrypt)
@@ -159,7 +159,7 @@ class DoctrineEncryptSubscriberTest extends TestCase
         $this->triggerProcessFields($withUser, true);
 
         $this->assertStringStartsWith('encrypted-', $withUser->name);
-        $this->assertSame('foo', $withUser->foo);
+        static::assertSame('foo', $withUser->foo);
         $this->assertStringStartsWith('encrypted-', $withUser->user->name);
         $this->assertStringStartsWith('encrypted-', $withUser->user->getAddress());
     }
@@ -181,8 +181,8 @@ class DoctrineEncryptSubscriberTest extends TestCase
         $this->subscriber->setEncryptor(null);
         $this->triggerProcessFields($user, true);
 
-        $this->assertSame('David', $user->name);
-        $this->assertSame('Switzerland', $user->getAddress());
+        static::assertSame('David', $user->name);
+        static::assertSame('Switzerland', $user->getAddress());
     }
 
     public function testProcessFieldsDecrypt(): void
@@ -191,8 +191,8 @@ class DoctrineEncryptSubscriberTest extends TestCase
 
         $this->triggerProcessFields($user, false);
 
-        $this->assertSame('David', $user->name);
-        $this->assertSame('Switzerland', $user->getAddress());
+        static::assertSame('David', $user->name);
+        static::assertSame('Switzerland', $user->getAddress());
     }
 
     public function testProcessFieldsDecryptExtended(): void
@@ -201,9 +201,9 @@ class DoctrineEncryptSubscriberTest extends TestCase
 
         $this->triggerProcessFields($user, false);
 
-        $this->assertSame('David', $user->name);
-        $this->assertSame('Switzerland', $user->getAddress());
-        $this->assertSame('extra', $user->extra);
+        static::assertSame('David', $user->name);
+        static::assertSame('Switzerland', $user->getAddress());
+        static::assertSame('extra', $user->extra);
     }
 
     public function testProcessFieldsDecryptEmbedded(): void
@@ -212,10 +212,10 @@ class DoctrineEncryptSubscriberTest extends TestCase
 
         $this->triggerProcessFields($withUser, false);
 
-        $this->assertSame('Thing', $withUser->name);
-        $this->assertSame('foo', $withUser->foo);
-        $this->assertSame('David', $withUser->user->name);
-        $this->assertSame('Switzerland', $withUser->user->getAddress());
+        static::assertSame('Thing', $withUser->name);
+        static::assertSame('foo', $withUser->foo);
+        static::assertSame('David', $withUser->user->name);
+        static::assertSame('Switzerland', $withUser->user->getAddress());
     }
 
     public function testProcessFieldsDecryptNull(): void
@@ -224,7 +224,7 @@ class DoctrineEncryptSubscriberTest extends TestCase
 
         $this->triggerProcessFields($user, false);
 
-        $this->assertSame('David', $user->name);
+        static::assertSame('David', $user->name);
         $this->assertNull($user->getAddress());
     }
 
@@ -235,8 +235,8 @@ class DoctrineEncryptSubscriberTest extends TestCase
 
         $this->triggerProcessFields($user, false);
 
-        $this->assertSame('encrypted-David', $user->name);
-        $this->assertSame('encrypted-Switzerland', $user->getAddress());
+        static::assertSame('encrypted-David', $user->name);
+        static::assertSame('encrypted-Switzerland', $user->getAddress());
     }
 
     /**
@@ -314,8 +314,8 @@ class DoctrineEncryptSubscriberTest extends TestCase
 
         $this->subscriber->postFlush($postFlush);
 
-        $this->assertSame('David', $user->name);
-        $this->assertSame('Switzerland', $user->getAddress());
+        static::assertSame('David', $user->name);
+        static::assertSame('Switzerland', $user->getAddress());
     }
 
     public function testAnnotationsAreOnlyReadOnce(): void


### PR DESCRIPTION
Fixes #46.

The SCA is also restored for the `tests/` directory.