### PR TITLE
Add missing `use` statement for `PropertyAccessorInterface`

### DIFF
--- a/src/Subscribers/DoctrineEncryptSubscriber.php
+++ b/src/Subscribers/DoctrineEncryptSubscriber.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\Event\PreFlushEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
  * Doctrine event subscriber which encrypt/decrypt entities.


### PR DESCRIPTION
https://github.com/DoctrineEncryptBundle/DoctrineEncryptBundle/blob/aa7565234bdadf66f395294603b6ccbc2e7f97aa/src/Subscribers/DoctrineEncryptSubscriber.php#L66