### PR TITLE
Bump PHPStan level to 3

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,6 +16,16 @@ parameters:
 			path: src/Command/DoctrineEncryptStatusCommand.php
 
 		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeDefinition\\:\\:children\\(\\)\\.$#"
+			count: 1
+			path: src/DependencyInjection/Configuration.php
+
+		-
+			message: "#^Access to property \\$queries on an unknown class Doctrine\\\\DBAL\\\\Logging\\\\DebugStack\\.$#"
+			count: 3
+			path: tests/Functional/AbstractFunctionalTestCase.php
+
+		-
 			message: "#^Call to an undefined static method Doctrine\\\\ORM\\\\EntityManager\\:\\:create\\(\\)\\.$#"
 			count: 1
 			path: tests/Functional/AbstractFunctionalTestCase.php
@@ -29,3 +39,23 @@ parameters:
 			message: "#^Instantiated class Doctrine\\\\DBAL\\\\Logging\\\\DebugStack not found\\.$#"
 			count: 1
 			path: tests/Functional/AbstractFunctionalTestCase.php
+
+		-
+			message: "#^Property Ambta\\\\DoctrineEncryptBundle\\\\Tests\\\\Functional\\\\AbstractFunctionalTestCase\\:\\:\\$sqlLoggerStack has unknown class Doctrine\\\\DBAL\\\\Logging\\\\DebugStack as its type\\.$#"
+			count: 1
+			path: tests/Functional/AbstractFunctionalTestCase.php
+
+		-
+			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Statement\\:\\:fetch\\(\\)\\.$#"
+			count: 1
+			path: tests/Functional/DoctrineEncryptSubscriber/AbstractDoctrineEncryptSubscriberTestCase.php
+
+		-
+			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Statement\\:\\:fetchAll\\(\\)\\.$#"
+			count: 1
+			path: tests/Functional/DoctrineEncryptSubscriber/AbstractDoctrineEncryptSubscriberTestCase.php
+
+		-
+			message: "#^Call to private method execute\\(\\) of class Doctrine\\\\DBAL\\\\Statement\\.$#"
+			count: 2
+			path: tests/Functional/DoctrineEncryptSubscriber/AbstractDoctrineEncryptSubscriberTestCase.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,7 +2,7 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-	level: 1
+	level: 3
 	paths:
 		- src
 		- tests

--- a/src/Command/DoctrineDecryptDatabaseCommand.php
+++ b/src/Command/DoctrineDecryptDatabaseCommand.php
@@ -6,6 +6,7 @@ use Ambta\DoctrineEncryptBundle\DependencyInjection\DoctrineEncryptExtension;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -34,6 +35,8 @@ class DoctrineDecryptDatabaseCommand extends AbstractCommand
     {
         // Get entity manager, question helper, subscriber service and annotation reader
         $question = $this->getHelper('question');
+
+        \assert($question instanceof QuestionHelper);
 
         // Get list of supported encryptors
         $supportedExtensions = DoctrineEncryptExtension::SupportedEncryptorClasses;

--- a/src/Command/DoctrineEncryptDatabaseCommand.php
+++ b/src/Command/DoctrineEncryptDatabaseCommand.php
@@ -4,6 +4,7 @@ namespace Ambta\DoctrineEncryptBundle\Command;
 
 use Ambta\DoctrineEncryptBundle\DependencyInjection\DoctrineEncryptExtension;
 use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -31,7 +32,8 @@ class DoctrineEncryptDatabaseCommand extends AbstractCommand
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // Get entity manager, question helper, subscriber service and annotation reader
-        $question  = $this->getHelper('question');
+        $question = $this->getHelper('question');
+        \assert($question instanceof QuestionHelper);
         $batchSize = $input->getArgument('batchSize');
 
         // Get list of supported encryptors

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -18,15 +18,10 @@ class Configuration implements ConfigurationInterface
     {
         // Create tree builder
         $treeBuilder = new TreeBuilder('ambta_doctrine_encrypt');
-        if (\method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->getRootNode();
-        } else {
-            // BC layer for symfony/config 4.1 and older
-            $rootNode = $treeBuilder->root('ambta_doctrine_encrypt');
-        }
 
         // Grammar of config tree
-        $rootNode
+        $treeBuilder
+            ->getRootNode()
             ->beforeNormalization()
                 ->always(function ($v) {
                     if (isset($v['secret']) && isset($v['secret_directory_path'])) {

--- a/src/Subscribers/DoctrineEncryptSubscriber.php
+++ b/src/Subscribers/DoctrineEncryptSubscriber.php
@@ -155,8 +155,14 @@ class DoctrineEncryptSubscriber implements EventSubscriber
      */
     public function preFlush(PreFlushEventArgs $preFlushEventArgs)
     {
-        $objectManager = method_exists($preFlushEventArgs, 'getObjectManager') ? $preFlushEventArgs->getObjectManager() : $preFlushEventArgs->getEntityManager();
-        $unitOfWork    = $objectManager->getUnitOfWork();
+        if (method_exists($preFlushEventArgs, 'getObjectManager')) {
+            $objectManager = $preFlushEventArgs->getObjectManager();
+        } else {
+            \assert(method_exists($preFlushEventArgs, 'getEntityManager'));
+            $objectManager = $preFlushEventArgs->getEntityManager();
+        }
+
+        $unitOfWork = $objectManager->getUnitOfWork();
         foreach ($unitOfWork->getIdentityMap() as $entityName => $entityArray) {
             if (isset($this->cachedDecryptions[$entityName])) {
                 foreach ($entityArray as $entityId => $instance) {
@@ -173,8 +179,14 @@ class DoctrineEncryptSubscriber implements EventSubscriber
      */
     public function onFlush(OnFlushEventArgs $onFlushEventArgs)
     {
-        $objectManager = method_exists($onFlushEventArgs, 'getObjectManager') ? $onFlushEventArgs->getObjectManager() : $onFlushEventArgs->getEntityManager();
-        $unitOfWork    = $objectManager->getUnitOfWork();
+        if (method_exists($onFlushEventArgs, 'getObjectManager')) {
+            $objectManager = $onFlushEventArgs->getObjectManager();
+        } else {
+            \assert(method_exists($onFlushEventArgs, 'getEntityManager'));
+            $objectManager = $onFlushEventArgs->getEntityManager();
+        }
+
+        $unitOfWork = $objectManager->getUnitOfWork();
         foreach ([$unitOfWork->getScheduledEntityUpdates(), $unitOfWork->getScheduledEntityInsertions()] as $scheduledEntities) {
             foreach ($scheduledEntities as $entity) {
                 $encryptCounterBefore = $this->encryptCounter;
@@ -193,8 +205,14 @@ class DoctrineEncryptSubscriber implements EventSubscriber
      */
     public function postFlush(PostFlushEventArgs $postFlushEventArgs)
     {
-        $objectManager = method_exists($postFlushEventArgs, 'getObjectManager') ? $postFlushEventArgs->getObjectManager() : $postFlushEventArgs->getEntityManager();
-        $unitOfWork    = $objectManager->getUnitOfWork();
+        if (method_exists($postFlushEventArgs, 'getObjectManager')) {
+            $objectManager = $postFlushEventArgs->getObjectManager();
+        } else {
+            \assert(method_exists($postFlushEventArgs, 'getEntityManager'));
+            $objectManager = $postFlushEventArgs->getEntityManager();
+        }
+
+        $unitOfWork = $objectManager->getUnitOfWork();
         foreach ($unitOfWork->getIdentityMap() as $entityMap) {
             foreach ($entityMap as $entity) {
                 if (method_exists($entity, '__isInitialized') && !$entity->__isInitialized()) {


### PR DESCRIPTION
The check for `\method_exists($treeBuilder, 'getRootNode')` was removed as the minimum allowed version for "symfony/config" is `5.4.0`: https://github.com/DoctrineEncryptBundle/DoctrineEncryptBundle/blob/43ef699ffbaf4d64af0b13cbd955cb69e6559191/composer.json#L17

I'll create other PR about the findings related to "doctrine/dbal", as this dependency is not even declared at `composer.json`.