### PR TITLE
Make it optional to depend on doctrine/annotations

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -2,6 +2,8 @@
     "symbol-whitelist" : [
         "Defuse\\Crypto\\Crypto",
         "Doctrine\\ORM\\Mapping\\ClassMetadataInfo",
+        "Doctrine\\Common\\Annotations\\PsrCachedReader",
+        "Doctrine\\Common\\Annotations\\Reader",
         "ParagonIE\\HiddenString\\HiddenString",
         "Symfony\\Contracts\\Service\\Attribute\\Required"
     ]

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "php": ">=8.2",
         "composer-runtime-api": "^2.0",
         "composer/semver": "^3.0",
-        "doctrine/annotations": "^1.13 || ^2.0",
         "doctrine/common": "^3.4",
         "doctrine/dbal": "^2.13.9 || ^3.9.4 || ^4.2.2",
         "doctrine/doctrine-bundle": "^2.12.0 || ^3.0.0",
@@ -34,6 +33,7 @@
     },
     "require-dev": {
         "defuse/php-encryption": "^2.1",
+        "doctrine/annotations": "^2.0",
         "doctrine/cache": "^1.11",
         "ergebnis/composer-normalize": "^2.48",
         "friendsofphp/php-cs-fixer": "^3.64.0",

--- a/demo/symfony6.x-types/composer.json
+++ b/demo/symfony6.x-types/composer.json
@@ -7,6 +7,7 @@
         "php": ">=8.1",
         "ext-ctype": "*",
         "ext-iconv": "*",
+        "doctrine/annotations": "^2.0",
         "doctrine/doctrine-bundle": "^2.14 || ^3.0",
         "doctrine/orm": "^2.12",
         "doctrineencryptbundle/doctrine-encrypt-bundle": "@dev",

--- a/demo/symfony6.x/composer.json
+++ b/demo/symfony6.x/composer.json
@@ -7,6 +7,7 @@
         "php": ">=8.1",
         "ext-ctype": "*",
         "ext-iconv": "*",
+        "doctrine/annotations": "^2.0",
         "doctrine/doctrine-bundle": "^2.14 || ^3.0",
         "doctrine/orm": "^2.12",
         "doctrineencryptbundle/doctrine-encrypt-bundle": "@dev",

--- a/demo/symfony6.x/symfony.lock
+++ b/demo/symfony6.x/symfony.lock
@@ -1,15 +1,12 @@
 {
     "doctrine/annotations": {
-        "version": "1.13",
+        "version": "2.0",
         "recipe": {
             "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "1.0",
-            "ref": "a2759dd6123694c8d901d0ec80006e044c2e6457"
-        },
-        "files": [
-            "config/routes/annotations.yaml"
-        ]
+            "branch": "main",
+            "version": "1.10",
+            "ref": "64d8583af5ea57b7afa4aba4b159907f3a148b05"
+        }
     },
     "doctrine/collections": {
         "version": "1.6.8"

--- a/src/AmbtaDoctrineEncryptBundle.php
+++ b/src/AmbtaDoctrineEncryptBundle.php
@@ -2,15 +2,27 @@
 
 namespace Ambta\DoctrineEncryptBundle;
 
+use Ambta\DoctrineEncryptBundle\DependencyInjection\ConfigureMappingReaderPass;
 use Ambta\DoctrineEncryptBundle\DependencyInjection\DoctrineEncryptExtension;
 use Ambta\DoctrineEncryptBundle\Factories\EncryptServiceFactory;
 use Ambta\DoctrineEncryptBundle\Service\EncryptService;
 use Doctrine\DBAL\Types\Type;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class AmbtaDoctrineEncryptBundle extends Bundle
 {
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(
+            new ConfigureMappingReaderPass(),
+            priority: 20, // Higher than Doctrine's default priority to make sure orm-subscriber/listener are properly registered
+        );
+    }
+
     public function boot(): void
     {
         $connections            = $this->container->get('doctrine')->getConnections();

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -2,10 +2,10 @@
 
 namespace Ambta\DoctrineEncryptBundle\Command;
 
+use Ambta\DoctrineEncryptBundle\Mapping\MappingReader;
 use Ambta\DoctrineEncryptBundle\Service\EncryptService;
 use Ambta\DoctrineEncryptBundle\Service\EncryptServiceAwareInterface;
 use Ambta\DoctrineEncryptBundle\Subscribers\DoctrineEncryptSubscriber;
-use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
@@ -19,44 +19,17 @@ use Symfony\Component\Console\Command\Command;
 abstract class AbstractCommand extends Command
 {
     /**
-     * @var EntityManagerInterface|EntityManager
-     */
-    protected $entityManager;
-
-    /**
-     * @var DoctrineEncryptSubscriber
-     */
-    protected $subscriber;
-
-    /**
-     * @var \Ambta\DoctrineEncryptBundle\Mapping\AttributeReader|\Ambta\DoctrineEncryptBundle\Mapping\AttributeAnnotationReader
-     */
-    protected $annotationReader;
-
-    /**
-     * @var EncryptServiceAwareInterface
-     */
-    protected $encryptService;
-
-    /**
      * AbstractCommand constructor.
-     *
-     * @param EntityManager                                                                                                       $entityManager
-     * @param \Ambta\DoctrineEncryptBundle\Mapping\AttributeReader|\Ambta\DoctrineEncryptBundle\Mapping\AttributeAnnotationReader $annotationReader
      *
      * @return void
      */
     public function __construct(
-        EntityManagerInterface $entityManager,
-        $annotationReader,
-        DoctrineEncryptSubscriber $subscriber,
-        EncryptServiceAwareInterface $encryptService
+        protected readonly EntityManagerInterface $entityManager,
+        protected readonly MappingReader $mappingReader,
+        protected readonly DoctrineEncryptSubscriber $subscriber,
+        protected readonly EncryptServiceAwareInterface $encryptService
     ) {
         parent::__construct();
-        $this->entityManager    = $entityManager;
-        $this->annotationReader = $annotationReader;
-        $this->subscriber       = $subscriber;
-        $this->encryptService   = $encryptService;
     }
 
     /**
@@ -148,7 +121,7 @@ abstract class AbstractCommand extends Command
         $properties      = [];
 
         foreach ($propertyArray as $property) {
-            if ($this->annotationReader->getPropertyAnnotation($property, 'Ambta\DoctrineEncryptBundle\Configuration\Encrypted')) {
+            if ($this->mappingReader->getPropertyAnnotation($property, 'Ambta\DoctrineEncryptBundle\Configuration\Encrypted')) {
                 $properties[] = $property;
             }
         }

--- a/src/Command/DoctrineDecryptDatabaseCommand.php
+++ b/src/Command/DoctrineDecryptDatabaseCommand.php
@@ -135,7 +135,7 @@ final class DoctrineDecryptDatabaseCommand extends AbstractCommand
                     if (!is_null($value)) {
                         ++$valueCounter;
 
-                        $annotation      = $this->annotationReader->getPropertyAnnotation($property, Encrypted::class);
+                        $annotation      = $this->mappingReader->getPropertyAnnotation($property, Encrypted::class);
                         $newValue        = $this->encryptService->decrypt($annotation->type, $value);
                         $encryptDbalType = Type::getType($annotation->type);
                         $usedValue       = $encryptDbalType->convertToDatabaseValue($newValue, $platform);

--- a/src/Command/DoctrineEncryptDatabaseCommand.php
+++ b/src/Command/DoctrineEncryptDatabaseCommand.php
@@ -134,7 +134,7 @@ final class DoctrineEncryptDatabaseCommand extends AbstractCommand
                         ++$valueCounter;
 
                         if (substr($value, -strlen(EncryptService::ENCRYPTION_MARKER)) != EncryptService::ENCRYPTION_MARKER) {
-                            $annotation      = $this->annotationReader->getPropertyAnnotation($property, 'Ambta\DoctrineEncryptBundle\Configuration\Encrypted');
+                            $annotation      = $this->mappingReader->getPropertyAnnotation($property, 'Ambta\DoctrineEncryptBundle\Configuration\Encrypted');
                             $encryptDbalType = Type::getType($annotation->type);
                             $newValue        = $encryptDbalType->convertToPHPValue($value, $platform);
                             $usedValue       = $this->encryptService->encrypt($annotation->type, $newValue);

--- a/src/DependencyInjection/ConfigureMappingReaderPass.php
+++ b/src/DependencyInjection/ConfigureMappingReaderPass.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ambta\DoctrineEncryptBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader;
+
+final class ConfigureMappingReaderPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+
+        if ($container->has('annotations.reader')) {
+            $loader->load('services_subscriber_with_annotations_and_attributes.yml');
+        } else {
+            $loader->load('service_listeners_with_attributes.yml');
+        }
+    }
+}

--- a/src/DependencyInjection/DoctrineEncryptExtension.php
+++ b/src/DependencyInjection/DoctrineEncryptExtension.php
@@ -62,19 +62,7 @@ class DoctrineEncryptExtension extends Extension
             throw new \RuntimeException('doctrineencryptbundle/doctrine-encrypt-bundle expects symfony-version >= 5.4!');
         }
 
-        // Symfony 5-6
-        if (Kernel::MAJOR_VERSION < 7) {
-            // PHP 8.x (annotations and attributes)
-            // Doctrine 3.0 - no annotations
-            if (\Composer\InstalledVersions::satisfies(new \Composer\Semver\VersionParser(), 'doctrine/orm', '^3.0')) {
-                $loader->load('service_listeners_with_attributes.yml');
-            } else {
-                $loader->load('services_subscriber_with_annotations_and_attributes.yml');
-            }
-        // Symfony 7 (only attributes)
-        } else {
-            $loader->load('service_listeners_with_attributes.yml');
-        }
+        // Actual definition of the services regarding orm-subscriber/listener is now done in the ConfigureMappingReaderPass.
     }
 
     /**

--- a/src/Mapping/AttributeAnnotationReader.php
+++ b/src/Mapping/AttributeAnnotationReader.php
@@ -12,21 +12,15 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
  *
  * @internal
  */
-final class AttributeAnnotationReader implements Reader
+final class AttributeAnnotationReader implements Reader, MappingReader
 {
-    /**
-     * @var Reader
-     */
-    private $annotationReader;
+    private readonly Reader $annotationReader;
 
-    /**
-     * @var AttributeReader
-     */
-    private $attributeReader;
-
-    public function __construct(AttributeReader $attributeReader, Reader $annotationReader, string $cacheDir)
-    {
-        $this->attributeReader  = $attributeReader;
+    public function __construct(
+        private readonly AttributeReader $attributeReader,
+        Reader $annotationReader,
+        string $cacheDir,
+    ) {
         $annotationsCache       = new FilesystemAdapter('', 0, $cacheDir.'/doctrine_encrypt');
         $this->annotationReader = new PsrCachedReader($annotationReader, $annotationsCache);
     }

--- a/src/Mapping/AttributeReader.php
+++ b/src/Mapping/AttributeReader.php
@@ -9,7 +9,7 @@ use Ambta\DoctrineEncryptBundle\Configuration\Annotation;
  *
  * @internal
  */
-final class AttributeReader
+final class AttributeReader implements MappingReader
 {
     /** @var array */
     private $isRepeatableAttribute = [];
@@ -23,11 +23,13 @@ final class AttributeReader
     }
 
     /**
-     * @phpstan-param class-string $annotationName
+     * @param class-string<T> $annotationName the name of the annotation
      *
-     * @return Annotation|Annotation[]|null
+     * @return T|null the Annotation or NULL, if the requested annotation does not exist
+     *
+     * @template T
      */
-    public function getClassAnnotation(\ReflectionClass $class, string $annotationName)
+    public function getClassAnnotation(\ReflectionClass $class, $annotationName)
     {
         return $this->getClassAnnotations($class)[$annotationName] ?? null;
     }
@@ -41,11 +43,13 @@ final class AttributeReader
     }
 
     /**
-     * @phpstan-param class-string $annotationName
+     * @param class-string<T> $annotationName the name of the annotation
      *
-     * @return Annotation|Annotation[]|null
+     * @return T|null the Annotation or NULL, if the requested annotation does not exist
+     *
+     * @template T
      */
-    public function getPropertyAnnotation(\ReflectionProperty $property, string $annotationName)
+    public function getPropertyAnnotation(\ReflectionProperty $property, $annotationName)
     {
         return $this->getPropertyAnnotations($property)[$annotationName] ?? null;
     }

--- a/src/Mapping/MappingReader.php
+++ b/src/Mapping/MappingReader.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ambta\DoctrineEncryptBundle\Mapping;
+
+/**
+ * This is a duplicate of \Doctrine\Common\Annotations\Reader to be have a mutual contract between both readers.
+ */
+interface MappingReader
+{
+    /**
+     * Gets the annotations applied to a class.
+     *
+     * @param \ReflectionClass $class the ReflectionClass of the class from which
+     *                                the class annotations should be read
+     *
+     * @return array<object> an array of Annotations
+     */
+    public function getClassAnnotations(\ReflectionClass $class);
+
+    /**
+     * Gets a class annotation.
+     *
+     * @param \ReflectionClass $class          the ReflectionClass of the class from which
+     *                                         the class annotations should be read
+     * @param class-string<T>  $annotationName the name of the annotation
+     *
+     * @return T|null the Annotation or NULL, if the requested annotation does not exist
+     *
+     * @template T
+     */
+    public function getClassAnnotation(\ReflectionClass $class, $annotationName);
+
+    /**
+     * Gets the annotations applied to a property.
+     *
+     * @param \ReflectionProperty $property the ReflectionProperty of the property
+     *                                      from which the annotations should be read
+     *
+     * @return array<object> an array of Annotations
+     */
+    public function getPropertyAnnotations(\ReflectionProperty $property);
+
+    /**
+     * Gets a property annotation.
+     *
+     * @param \ReflectionProperty $property       the ReflectionProperty to read the annotations from
+     * @param class-string<T>     $annotationName the name of the annotation
+     *
+     * @return T|null the Annotation or NULL, if the requested annotation does not exist
+     *
+     * @template T
+     */
+    public function getPropertyAnnotation(\ReflectionProperty $property, $annotationName);
+}

--- a/src/Subscribers/DoctrineEncryptSubscriber.php
+++ b/src/Subscribers/DoctrineEncryptSubscriber.php
@@ -4,8 +4,7 @@ namespace Ambta\DoctrineEncryptBundle\Subscribers;
 
 use Ambta\DoctrineEncryptBundle\Encryptors\EncryptorInterface;
 use Ambta\DoctrineEncryptBundle\Exception\DoctrineEncryptBundleException;
-use Ambta\DoctrineEncryptBundle\Mapping\AttributeReader;
-use Doctrine\Common\Annotations\Reader;
+use Ambta\DoctrineEncryptBundle\Mapping\MappingReader;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
@@ -39,19 +38,8 @@ class DoctrineEncryptSubscriber implements EventSubscriber
      */
     public const ENCRYPTED_ANN_NAME = 'Ambta\DoctrineEncryptBundle\Configuration\Encrypted';
 
-    /**
-     * Encryptor.
-     *
-     * @var EncryptorInterface|null
-     */
-    private $encryptor;
-
-    /**
-     * Annotation reader.
-     *
-     * @var Reader|AttributeReader
-     */
-    private $annReader;
+    private ?EncryptorInterface $encryptor;
+    private readonly MappingReader $mappingReader;
 
     /**
      * Used for restoring the encryptor after changing it.
@@ -69,42 +57,23 @@ class DoctrineEncryptSubscriber implements EventSubscriber
 
     /**
      * Count amount of decrypted values in this service.
-     *
-     * @var int
      */
-    public $decryptCounter = 0;
+    public int $decryptCounter = 0;
 
     /**
      * Count amount of encrypted values in this service.
-     *
-     * @var int
      */
-    public $encryptCounter = 0;
+    public int $encryptCounter = 0;
 
-    /** @var array */
-    private $cachedDecryptions = [];
+    private array $cachedDecryptions                     = [];
+    private array $cachedClassProperties                 = [];
+    private array $cachedClassPropertiesAreEmbedded      = [];
+    private array $cachedClassPropertiesAreEncrypted     = [];
+    private array $cachedClassesContainAnEncryptProperty = [];
 
-    /** @var array */
-    private $cachedClassProperties = [];
-
-    /** @var array */
-    private $cachedClassPropertiesAreEmbedded = [];
-
-    /** @var array */
-    private $cachedClassPropertiesAreEncrypted = [];
-
-    /** @var array */
-    private $cachedClassesContainAnEncryptProperty = [];
-
-    /**
-     * Initialization of subscriber.
-     *
-     * @param Reader|AttributeReader $annReader
-     * @param EncryptorInterface     $encryptor (Optional)  An EncryptorInterface
-     */
-    public function __construct($annReader, EncryptorInterface $encryptor)
+    public function __construct(MappingReader $mappingReader, EncryptorInterface $encryptor)
     {
-        $this->annReader        = $annReader;
+        $this->mappingReader    = $mappingReader;
         $this->encryptor        = $encryptor;
         $this->restoreEncryptor = $this->encryptor;
         $this->pac              = PropertyAccess::createPropertyAccessor();
@@ -385,7 +354,7 @@ class DoctrineEncryptSubscriber implements EventSubscriber
     {
         $key = $refProperty->getDeclaringClass()->getName().$refProperty->getName();
         if (!array_key_exists($key, $this->cachedClassPropertiesAreEmbedded)) {
-            $this->cachedClassPropertiesAreEmbedded[$key] = (bool) $this->annReader->getPropertyAnnotation($refProperty, 'Doctrine\ORM\Mapping\Embedded');
+            $this->cachedClassPropertiesAreEmbedded[$key] = (bool) $this->mappingReader->getPropertyAnnotation($refProperty, 'Doctrine\ORM\Mapping\Embedded');
         }
 
         return $this->cachedClassPropertiesAreEmbedded[$key];
@@ -399,7 +368,7 @@ class DoctrineEncryptSubscriber implements EventSubscriber
         $key = $refProperty->getDeclaringClass()->getName().$refProperty->getName();
         if (!array_key_exists($key, $this->cachedClassPropertiesAreEncrypted)) {
             $type               = null;
-            $propertyAnnotation = $this->annReader->getPropertyAnnotation($refProperty, self::ENCRYPTED_ANN_NAME);
+            $propertyAnnotation = $this->mappingReader->getPropertyAnnotation($refProperty, self::ENCRYPTED_ANN_NAME);
             if ($propertyAnnotation) {
                 $type = $propertyAnnotation->type;
             }

--- a/tests/DoctrineCompatibilityTrait.php
+++ b/tests/DoctrineCompatibilityTrait.php
@@ -214,11 +214,10 @@ trait DoctrineCompatibilityTrait
     {
         if (method_exists($statement, 'executeQuery')) {
             return $statement->executeQuery()->fetchAllAssociative();
-        } else {
-            $statement->execute();
-
-            return $statement->fetchAll();
         }
+        $statement->execute();
+
+        return $statement->fetchAll();
     }
 
     /**
@@ -230,10 +229,9 @@ trait DoctrineCompatibilityTrait
     {
         if (method_exists($statement, 'executeQuery')) {
             return $statement->executeQuery()->fetchAssociative();
-        } else {
-            $statement->execute();
-
-            return $statement->fetch();
         }
+        $statement->execute();
+
+        return $statement->fetch();
     }
 }

--- a/tests/Unit/DependencyInjection/DoctrineEncryptExtensionTest.php
+++ b/tests/Unit/DependencyInjection/DoctrineEncryptExtensionTest.php
@@ -2,14 +2,18 @@
 
 namespace Ambta\DoctrineEncryptBundle\Tests\Unit\DependencyInjection;
 
+use Ambta\DoctrineEncryptBundle\DependencyInjection\ConfigureMappingReaderPass;
 use Ambta\DoctrineEncryptBundle\DependencyInjection\DoctrineEncryptExtension;
 use Ambta\DoctrineEncryptBundle\Encryptors\DefuseEncryptor;
 use Ambta\DoctrineEncryptBundle\Encryptors\HaliteEncryptor;
+use Ambta\DoctrineEncryptBundle\Mapping\AttributeAnnotationReader;
+use Ambta\DoctrineEncryptBundle\Mapping\AttributeReader;
 use ParagonIE\Halite\KeyFactory;
 use ParagonIE\HiddenString\HiddenString;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\ExpressionLanguage\Expression;
 
@@ -17,12 +21,8 @@ class DoctrineEncryptExtensionTest extends TestCase
 {
     use ExpectDeprecationTrait;
 
-    /**
-     * @var DoctrineEncryptExtension
-     */
-    private $extension;
-
-    private $temporaryDirectory;
+    private DoctrineEncryptExtension $extension;
+    private string $temporaryDirectory;
 
     protected function setUp(): void
     {
@@ -204,11 +204,52 @@ class DoctrineEncryptExtensionTest extends TestCase
         static::assertEquals($expectedSecret, $actualSecret);
     }
 
+    public function testLoadConfigWithFrameworkAnnotationsDisabled(): void
+    {
+        $container = $this->createContainerWithFrameworkBundle(annotationsEnabled: false);
+        $this->extension->load([], $container);
+
+        // Register services for annotation/attribute reading
+        (new ConfigureMappingReaderPass())->process($container);
+
+        static::assertTrue($container->hasDefinition('ambta_doctrine_attribute_reader'));
+        static::assertSame(AttributeReader::class, $container->getDefinition('ambta_doctrine_attribute_reader')->getClass());
+
+        static::assertTrue($container->hasAlias('ambta_doctrine_annotation_reader'));
+        static::assertSame('ambta_doctrine_attribute_reader', (string) $container->getAlias('ambta_doctrine_annotation_reader'));
+    }
+
+    public function testLoadConfigWithFrameworkAnnotationsEnabled(): void
+    {
+        $container = $this->createContainerWithFrameworkBundle(annotationsEnabled: true);
+        $this->extension->load([], $container);
+
+        // Register services for annotation/attribute reading
+        (new ConfigureMappingReaderPass())->process($container);
+
+        static::assertTrue($container->hasDefinition('ambta_doctrine_attribute_reader'));
+        static::assertSame(AttributeReader::class, $container->getDefinition('ambta_doctrine_attribute_reader')->getClass());
+
+        static::assertTrue($container->hasDefinition('ambta_doctrine_annotation_reader'));
+        static::assertSame(AttributeAnnotationReader::class, $container->getDefinition('ambta_doctrine_annotation_reader')->getClass());
+    }
+
     private function createContainer(): ContainerBuilder
     {
         $container = new ContainerBuilder(
             new ParameterBag(['kernel.debug' => false])
         );
+
+        return $container;
+    }
+
+    private function createContainerWithFrameworkBundle(bool $annotationsEnabled): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+
+        if ($annotationsEnabled) {
+            $container->setDefinition('annotations.reader', new Definition());
+        }
 
         return $container;
     }

--- a/tests/Unit/Subscribers/DoctrineEncryptSubscriberTest.php
+++ b/tests/Unit/Subscribers/DoctrineEncryptSubscriberTest.php
@@ -4,11 +4,11 @@ namespace Ambta\DoctrineEncryptBundle\Tests\Unit\Subscribers;
 
 use Ambta\DoctrineEncryptBundle\Configuration\Encrypted;
 use Ambta\DoctrineEncryptBundle\Encryptors\EncryptorInterface;
+use Ambta\DoctrineEncryptBundle\Mapping\MappingReader;
 use Ambta\DoctrineEncryptBundle\Subscribers\DoctrineEncryptSubscriber;
 use Ambta\DoctrineEncryptBundle\Tests\Unit\Subscribers\fixtures\ExtendedUser;
 use Ambta\DoctrineEncryptBundle\Tests\Unit\Subscribers\fixtures\User;
 use Ambta\DoctrineEncryptBundle\Tests\Unit\Subscribers\fixtures\WithUser;
-use Doctrine\Common\Annotations\Reader;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\ORM\EntityManagerInterface;
@@ -22,26 +22,12 @@ use PHPUnit\Framework\TestCase;
 
 class DoctrineEncryptSubscriberTest extends TestCase
 {
-    /**
-     * @var DoctrineEncryptSubscriber
-     */
-    private $subscriber;
+    private DoctrineEncryptSubscriber $subscriber;
 
-    /**
-     * @var EncryptorInterface|MockObject
-     */
-    private $encryptor;
-
-    /**
-     * @var Reader|MockObject
-     */
-    private $reader;
-
-    /** @var EntityManagerInterface|MockObject */
-    private $em;
-
-    /** @var Connection|MockObject */
-    private $conn;
+    private MockObject&EncryptorInterface $encryptor;
+    private MockObject&MappingReader $reader;
+    private MockObject&EntityManagerInterface $em;
+    private MockObject&Connection $conn;
 
     protected function createMock($originalClassName): MockObject
     {
@@ -73,7 +59,7 @@ class DoctrineEncryptSubscriberTest extends TestCase
             })
         ;
 
-        $this->reader = $this->createMock(Reader::class);
+        $this->reader = $this->createMock(MappingReader::class);
         $this->reader->expects($this->any())
             ->method('getPropertyAnnotation')
             ->willReturnCallback(function (\ReflectionProperty $reflProperty, string $class) {
@@ -324,7 +310,7 @@ class DoctrineEncryptSubscriberTest extends TestCase
 
     public function testAnnotationsAreOnlyReadOnce(): void
     {
-        $reader = $this->createMock(Reader::class);
+        $reader = $this->createMock(MappingReader::class);
         $reader->expects($this->exactly(4)) // 2 properties and test if embedded and encrypted
             ->method('getPropertyAnnotation')
             ->willReturnCallback(function (\ReflectionProperty $reflProperty, string $class) {


### PR DESCRIPTION
This PR adds the option to have the library installed without having `doctrine/annotations` installed.

This is mainly useful for symfony 6.4, as newer versions do not support annotations any more.

This should solve #70 and #33.

I've also done some cleanup by adding more types in files which were touched.

# How it works
Rather than defining all services in `DoctrineEncryptExtension`, the services regarding the annotations/attribute-reader are defined in `ConfigureMappingReaderPass`, which is registered during `DoctrineEncryptBundle::build()`.

In the compilerpass, we are able to detect if the service `annotations.reader` is defined, which is the default annotations-reader from doctrine which is available when annotations are enabled in the frameworkbundle and `doctrine/annotations` is installed. If either is not true, we only use the attributes.